### PR TITLE
Fixes and improvements in installation documentation

### DIFF
--- a/docs/installation/installation_steps/2_app_server.md
+++ b/docs/installation/installation_steps/2_app_server.md
@@ -36,8 +36,8 @@ $ git clone git@github.com:uwrit/leaf.git
 
     At the time of this writing, installing .NET on CentOS/RHEL looks like this:
     ```bash
-    $ rpm -Uvh https://packages.microsoft.com/config/rhel/7/packages-microsoft-prod.rpm
-    $ yum install -y dotnet-sdk-3.1
+    rpm -Uvh https://packages.microsoft.com/config/rhel/7/packages-microsoft-prod.rpm
+    yum install -y dotnet-sdk-3.1
     ```
 
     !!! info 
@@ -47,9 +47,9 @@ $ git clone git@github.com:uwrit/leaf.git
     .NET Core 3.1 can be installed on Ubuntu by running:
 
     ```sh
-    $ wget https://packages.microsoft.com/config/ubuntu/20.10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
-    $ sudo dpkg -i packages-microsoft-prod.deb
-    $ sudo apt-get update; \
+    wget https://packages.microsoft.com/config/ubuntu/20.10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+    sudo dpkg -i packages-microsoft-prod.deb
+    sudo apt-get update; \
         sudo apt-get install -y apt-transport-https && \
         sudo apt-get update && \
         sudo apt-get install -y dotnet-sdk-3.1

--- a/docs/installation/installation_steps/4_compile_api.md
+++ b/docs/installation/installation_steps/4_compile_api.md
@@ -18,13 +18,13 @@ From `/leaf/src/server`:
     === "With User Authentication"
 
         ```sh
-        $ dotnet publish -c Release -o /var/opt/leafapi/api
+        dotnet publish -c Release -o /var/opt/leafapi/api
         ```
 
     === "No Authentication (UNSECURED)"
 
         ```sh
-        $ dotnet publish -c Debug -o /var/opt/leafapi/api
+        dotnet publish -c Debug -o /var/opt/leafapi/api
         ```
 
 === "Windows"
@@ -32,13 +32,13 @@ From `/leaf/src/server`:
     === "With User Authentication"
 
         ```sh
-        $ dotnet publish -c Release -o <your_api_deployment_directory>
+        dotnet publish -c Release -o <your_api_deployment_directory>
         ```
 
     === "No Authentication (UNSECURED)"
 
         ```sh
-        $ dotnet publish -c Debug -o <your_api_deployment_directory>
+        dotnet publish -c Debug -o <your_api_deployment_directory>
         ```
 ---
 

--- a/docs/installation/installation_steps/5_compile_client.md
+++ b/docs/installation/installation_steps/5_compile_client.md
@@ -11,7 +11,7 @@ Like the Leaf API, Leaf Client as available on GitHub is not yet built for produ
 
 1. **Install dependencies**
 
-        $ cd /var/opt/leaf/leaf_download/leaf/
+        $ cd /var/opt/leafapi/leaf_download/leaf/
         $ cd src/ui-client/
         $ npm install
 

--- a/docs/installation/installation_steps/6_appsettings.md
+++ b/docs/installation/installation_steps/6_appsettings.md
@@ -26,7 +26,7 @@ As we already [compiled the API in Step 4](../4_compile_api), though, it can now
     - **Connection**: `LEAF_APP_DB` - Name of the Leaf app database connection string environment variable.
     - **DefaultTimeout**: Number of seconds allowed before a Leaf app database query times out.
 - **Clin**
-    - **Connection**: `LEAF_CLIN_DB` - Name of the Leaf app database connection string environment variable.
+    - **Connection**: `LEAF_CLIN_DB` - Name of the clinical database connection string environment variable.
     - **DefaultTimeout**: Number of seconds allowed before a clinical database query times out.
     - **Cohort**: 
         - **QueryStrategy**: `CTE | PARALLEL` - `CTE` queries wrap individual Leaf panel SQL within a single larger CTE query, and leverage the SQL engine to find the intersect. `PARALLEL` queries are performed concurrently by the Leaf API, which then map/reduces the results to find the intersect.
@@ -45,7 +45,7 @@ As we already [compiled the API in Step 4](../4_compile_api), though, it can now
 ## Authentication
 - **Mechanism**: `SAML2 | UNSECURED` - Only `SAML2` is currently supported for production. Use `UNSECURED` for development.
 - **SessionTimeoutMinutes**: Number of minutes allowed before a session expires. We recommend aligning this value with the timeout configuration other Service Provider used (e.g., Shibboleth).
-- **InactivityTimeoutMinutes**: Number of minutes allowed before a lack of user logs a user out of Leaf.
+- **InactivityTimeoutMinutes**: Number of minutes allowed before a lack of user activity logs a user out of Leaf.
 - **LogoutURI**: The URI/URL Leaf will redirect to in the browser upon user logout. For Shibboleth, this is typically of the form `https:<your_leaf_url>.edu/Shibboleth.sso/Logout?return=<Shibboleth_specific_logout_URL>`
 - **SAML2**
     - **Headers**
@@ -150,7 +150,7 @@ Example configurations:
 - **Visualize**
     - **Enabled**: `true | false` - Boolean which indicates whether the `Visualize` screen should be shown in the user interface. 
     ![Visualize](../images/visualize_example.png "Visualize")
-    - **ShowFederated**: `true | false` - Value which indicates whether the `Visualize` results for federated Leaf instances should be shown in the user interface. If `false`, only aggregate results from all Leaf instance will be shown.
+    - **ShowFederated**: `true | false` - Value which indicates whether the `Visualize` results for federated Leaf instances should be shown in the user interface. If `false`, only aggregate results from all Leaf instances will be shown.
 - **Timelines**
     - **Enabled**: `true | false` - Boolean which indicates whether the `Timelines` screen should be shown in the user interface. 
     ![Timelines](../images/timelines_example.gif "Timelines")

--- a/docs/installation/installation_steps/7_env.md
+++ b/docs/installation/installation_steps/7_env.md
@@ -2,7 +2,7 @@
 
 ![Infra](../images/infra_app_focus.png "Architecure-Focus-Example") 
 
-Leaf uses environment variables to store sensitive information, such as connection strings, which are loaded when the API is launched. Regardless of the OS and configuration, as a best practice we recommend using environment variables specific to the user account running the Leaf API (rather than global environment variables)
+Leaf uses environment variables to store sensitive information, such as connection strings, which are loaded when the API is launched. Regardless of the OS and configuration, as a best practice we recommend using environment variables specific to the user account running the Leaf API (rather than global environment variables).
 
 **Leaf environment variables with example values**:
 

--- a/docs/installation/installation_steps/8a_configure_apache.md
+++ b/docs/installation/installation_steps/8a_configure_apache.md
@@ -20,9 +20,10 @@ We'll start by deploying the Leaf API as a service using `systemctl`.
 1. Create a nologin user account to isolate the service from the operating system, and give that account ownership over the API -related folders.
 
     ```sh
-    $ useradd -r api_svc_account
-    $ chown /var/log/leaf/
-    $ chown -R /var/opt/leaf/
+    useradd -r api_svc_account
+    mkdir /var/log/leaf/
+    chown api_svc_account /var/log/leaf/
+    chown -R api_svc_account /var/opt/leafapi/
     ```
 
 2. Create a service file for the API instance. The `WorkingDirectory` must be the directory where `API.dll` resides.
@@ -50,13 +51,13 @@ We'll start by deploying the Leaf API as a service using `systemctl`.
 
     ```sh
     # Create a symbolic link into the systemd directory
-    $ ln -s /var/opt/leafapi/services/leaf_api.service /etc/systemd/system/leaf_api.service
+    ln -s /var/opt/leafapi/services/leaf_api.service /etc/systemd/system/leaf_api.service
 
     # Make the systemd aware of the service
-    $ systemctl daemon-reload
+    systemctl daemon-reload
 
     # Start the service
-    $ systemctl start leaf_api.service
+    systemctl start leaf_api.service
     ```
 
 ## Hosting Leaf with Apache
@@ -64,6 +65,11 @@ We'll start by deploying the Leaf API as a service using `systemctl`.
 ![Infra](../images/infra_web_focus.png "Architecure-Focus-Example") 
 
 Great, at this point the Leaf database and API should be up and running.
+The status of the Leaf API can be checked with this command:
+
+    ```sh
+    systemctl status leaf_api.service
+    ```
 
 1. **From the app server**, copy the `/build` directory made in [Step 5 - Build the Leaf UI](../5_compile_client) to `/data/www/` **on the web server**. This will copy the Leaf Client production files over for Apache to host.
 
@@ -72,7 +78,7 @@ Great, at this point the Leaf database and API should be up and running.
     !!! info 
         Each Leaf client webapp must be hosted at the top level of the `DocumentRoot` of an Apache VirtualHost. Multiple nodes could be hosted on a single Apache instance pointing at that same `DocumentRoot`, however each would need its own VirtualHost and unique DNS name defined (e.g., site1.leaf.school.edu, site2.leaf.school.edu).
 
-    In the below example, the Shibboleth module is used to authenticate users via SAML2 and provide group membership to the app. If you want to define your own set of groups that limit access to the app via apache (ie during pre-release or evaluation), you can define your own Apache groups via the AuthGroupFile directive and then require those groups.
+    In the below example, the Shibboleth module is used to authenticate users via SAML2 and provide group membership to the app. If you want to define your own set of groups that limit access to the app via Apache (i.e. during pre-release or evaluation), you can define your own Apache groups via the AuthGroupFile directive and then require those groups.
 
 **`httpd.conf`**
 


### PR DESCRIPTION
fix a couple of commands
fix an inconsistency between /var/opt/leaf and /var/opt/leafapi
fix some wording
remove some '$ ' prefixes to commands, so copy can be pasted in terminal